### PR TITLE
Fix path to sqlite3 in CFLAGS

### DIFF
--- a/q2/Makefile
+++ b/q2/Makefile
@@ -14,7 +14,7 @@ SQLITE=../sqlite3
 
 # gcc configuration
 CC = gcc
-CFLAGS = -I./$(IDIR) -I../$(SQLITE) -std=c99
+CFLAGS = -I./$(IDIR) -I$(SQLITE) -std=c99
 LIBS = -lm -lpthread -ldl
 
 .PHONY: directories clean

--- a/q3/Makefile
+++ b/q3/Makefile
@@ -14,7 +14,7 @@ SQLITE=../sqlite3
 
 # gcc configuration
 CC = gcc
-CFLAGS = -I./$(IDIR) -I../$(SQLITE) -std=c99
+CFLAGS = -I./$(IDIR) -I$(SQLITE) -std=c99
 LIBS = -lm -lpthread -ldl
 
 .PHONY: directories clean

--- a/q4/Makefile
+++ b/q4/Makefile
@@ -14,7 +14,7 @@ SQLITE=../sqlite3
 
 # gcc configuration
 CC = gcc
-CFLAGS = -I./$(IDIR) -I../$(SQLITE) -std=c99
+CFLAGS = -I./$(IDIR) -I$(SQLITE) -std=c99
 LIBS = -lm -lpthread -ldl
 
 .PHONY: directories clean

--- a/q5/Makefile
+++ b/q5/Makefile
@@ -14,7 +14,7 @@ SQLITE=../sqlite3
 
 # gcc configuration
 CC = gcc
-CFLAGS = -I./$(IDIR) -I../$(SQLITE) -std=c99
+CFLAGS = -I./$(IDIR) -I$(SQLITE) -std=c99
 LIBS = -lm -lpthread -ldl
 
 .PHONY: directories clean

--- a/q6/Makefile
+++ b/q6/Makefile
@@ -14,7 +14,7 @@ SQLITE=../sqlite3
 
 # gcc configuration
 CC = gcc
-CFLAGS = -I./$(IDIR) -I../$(SQLITE) -std=c99
+CFLAGS = -I./$(IDIR) -I$(SQLITE) -std=c99
 LIBS = -lm -lpthread -ldl
 
 .PHONY: directories clean


### PR DESCRIPTION
To be able to run tests in a local environment without global sqlite3.h installed, I have to fix the path. Otherwise, I will get errors below.
`
$ make test
mkdir -p obj
mkdir -p bin
compiling: gcc -c -o obj/solution.o src/solution.c  ../sqlite3/sqlite3.c -I./include -I../../sqlite3 -std=c99
gcc -c -o obj/solution.o src/solution.c -I./include -I../../sqlite3 -std=c99
src/solution.c:2:10: fatal error: sqlite3.h: No such file or directory
 #include <sqlite3.h>
          ^~~~~~~~~~~
compilation terminated.
Makefile:41: recipe for target 'obj/solution.o' failed
make: *** [obj/solution.o] Error 1
`